### PR TITLE
Parser, HTML, error message fixes

### DIFF
--- a/exec/contextfn_paths.go
+++ b/exec/contextfn_paths.go
@@ -32,6 +32,9 @@ func init() {
 	contextFunctions[symbols.NT_NameTestQNameLocalOnly] = execNameTestQNameLocalOnly
 	contextFunctions[symbols.NT_NameTestQNameLocalOnlyReservedNameConflict] = execNameTestQNameLocalOnly
 	contextFunctions[symbols.NT_StepWithAxisAndNodeTest] = leftRightDependentResult
+	contextFunctions[symbols.NT_StepWithAxisAndNodeTestAndPredicate] = leftRightDependentResult
+	contextFunctions[symbols.NT_StepWithPredicateWithAnotherPredicate] = leftRightDependentResult
+	contextFunctions[symbols.NT_FilterExprWithPredicate] = leftRightDependentResult
 	contextFunctions[symbols.NT_AxisName] = execAxisName
 	contextFunctions[symbols.NT_AbbreviatedStepParent] = execAbbreviatedStepParent
 	contextFunctions[symbols.NT_AbbreviatedAxisSpecifier] = execAbbreviatedAxisSpecifier

--- a/parser/html.go
+++ b/parser/html.go
@@ -118,6 +118,11 @@ func (x *htmlParser) Pull() (node.Node, bool, error) {
 		return nil, false, fmt.Errorf("encountered raw node")
 	case html.DocumentNode:
 		x.node = x.node.FirstChild
+
+		if x.node.Type != html.DoctypeNode {
+			return nil, false, fmt.Errorf("doctype declaration not found")
+		}
+
 		return x.Pull()
 	case html.DoctypeNode:
 		x.node = x.node.NextSibling


### PR DESCRIPTION
Added some missing parser symbols to the execution logic.  Do not parse HTML files if it does not contain a doctype declaration.  Made the error messages slightly more readable.